### PR TITLE
pkg-config usage

### DIFF
--- a/ext/exiv2/extconf.rb
+++ b/ext/exiv2/extconf.rb
@@ -1,4 +1,8 @@
 require 'mkmf'
 config = pkg_config('exiv2')
-$CPPFLAGS = [$CPPFLAGS, config[0]].join ' '
-create_makefile("exiv2/exiv2")
+if config
+  $CPPFLAGS = [$CPPFLAGS, config[0]].join ' '
+  create_makefile("exiv2/exiv2")
+else
+  abort 'exiv2 devel package is missing'
+end

--- a/ext/exiv2/extconf.rb
+++ b/ext/exiv2/extconf.rb
@@ -1,4 +1,4 @@
 require 'mkmf'
-dir_config("exiv2")
-have_library("exiv2")
+config = pkg_config('exiv2')
+$CPPFLAGS = [$CPPFLAGS, config[0]].join ' '
 create_makefile("exiv2/exiv2")


### PR DESCRIPTION
Fixed configuration on Linux and Mac boxes.
Declaration of paths is no more needed.