### PR TITLE
Use xfree over delete to be kinder to the ruby VM

### DIFF
--- a/ext/exiv2/exiv2.cpp
+++ b/ext/exiv2/exiv2.cpp
@@ -106,7 +106,7 @@ extern "C" void Init_exiv2() {
 // Exiv2::Image Methods
 
 static void image_free(Exiv2::Image* image) {
-  delete image;
+  xfree(image);
 }
 
 static VALUE image_read_metadata(VALUE self) {


### PR DESCRIPTION
This is an attempt to help/solve some segfaults and memory issues we've
been having.