### PR TITLE
Add default pkg-config to extconf.rb

### DIFF
--- a/ext/exiv2/extconf.rb
+++ b/ext/exiv2/extconf.rb
@@ -5,6 +5,7 @@ RbConfig::MAKEFILE_CONFIG['CCFLAGS'] = ENV['CCFLAGS'] if ENV['CCFLAGS']
 RbConfig::MAKEFILE_CONFIG['CXX'] = ENV['CXX'] if ENV['CXX']
 RbConfig::MAKEFILE_CONFIG['CXXFLAGS'] = ENV['CXXFLAGS'] if ENV['CXXFLAGS']
 
+pkg_config("exiv2")
 dir_config("exiv2")
 have_library("exiv2")
 create_makefile("exiv2/exiv2")


### PR DESCRIPTION
https://github.com/envato/exiv2/pull/11 continuation.

With this fix I don't need to provide paths manually on my machines (Linux and OS X) as described [in README](https://github.com/envato/exiv2#usage)
