### PR TITLE
Add support for exiv2 v0.27.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0
-  - 2.1
+  - 2.4
+  - 2.5
+  - 2.6
 before_script:
   - sudo apt-get install libexiv2-dev
 script:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ are welcome.
 
 ## Compatibility
 
-Tested on 1.9.3, 2.0.x and 2.1.x with Exiv2 0.27.1
+Tested on 2.4.x, 2.5.x and 2.6.x with Exiv2 0.27.1
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ are welcome.
 
 ## Compatibility
 
-Tested on 1.9.3, 2.0.x and 2.1.x with Exiv2 0.24
+Tested on 1.9.3, 2.0.x and 2.1.x with Exiv2 0.27.1
 
 ## Developing
 

--- a/ext/exiv2/exiv2.cpp
+++ b/ext/exiv2/exiv2.cpp
@@ -1,4 +1,5 @@
 #include "exiv2/image.hpp"
+#include "exiv2/error.hpp"
 #include "ruby.h"
 
 // Create a Ruby string from a C++ std::string.


### PR DESCRIPTION
The `BasicError` class was not being included because we were not
requiring a header that's present in v0.27.1. 

I have tested this on exiv versions 0.24 through to 0.27.1 and all work fine :) 