### PR TITLE
Bump version to 0.0.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exiv2 (0.0.9)
+    exiv2 (0.0.10)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/exiv2/version.rb
+++ b/lib/exiv2/version.rb
@@ -1,4 +1,4 @@
 # coding: utf-8
 module Exiv2
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end


### PR DESCRIPTION
Let's release v0.0.9 with the fix to make exiv 27.1 work with the gem :)
All future changes will go against the 0.0.10 release.

TODO:
  - [x] Release v0.0.9