### PR TITLE
Use pkg-config for library detection

### DIFF
--- a/ext/exiv2/extconf.rb
+++ b/ext/exiv2/extconf.rb
@@ -5,6 +5,8 @@ RbConfig::MAKEFILE_CONFIG['CCFLAGS'] = ENV['CCFLAGS'] if ENV['CCFLAGS']
 RbConfig::MAKEFILE_CONFIG['CXX'] = ENV['CXX'] if ENV['CXX']
 RbConfig::MAKEFILE_CONFIG['CXXFLAGS'] = ENV['CXXFLAGS'] if ENV['CXXFLAGS']
 
-dir_config("exiv2")
+if dir_config("exiv2") == [nil, nil]
+  pkg_config("exiv2")
+end
 have_library("exiv2")
 create_makefile("exiv2/exiv2")

--- a/lib/exiv2/version.rb
+++ b/lib/exiv2/version.rb
@@ -1,4 +1,4 @@
 # coding: utf-8
 module Exiv2
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end


### PR DESCRIPTION
Use pkg-config to find the location of exiv2. This removes the need to specify the location manually in all but very specific setups.
For example on a mac with homebrew, no specific bundler configuration is needed anymore.