### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ jobs:
   test:
     name: Test (Ruby ${{ matrix.ruby }})
     runs-on: ubuntu-latest
-    container: ruby:${{ matrix.ruby }}
     strategy:
       fail-fast: false
       matrix:
@@ -14,9 +13,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install libexiv2-dev
         run: |
-          apt-get update --quiet
-          apt-get install --quiet --yes --no-install-recommends libexiv2-dev
-      - name: Bundle
-        run: bundle install
+          sudo apt-get update --quiet
+          sudo apt-get install --quiet --yes --no-install-recommends libexiv2-dev
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - name: RSpec
         run: bundle exec rake spec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install libexiv2-dev
         run: |
           apt-get update --quiet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ruby:${{ matrix.ruby }}
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
     steps:


### PR DESCRIPTION
### Changes

* 13c5e9b bump actions/checkout from 2 to 3
   Resolves the deprecation warning:

   > Node.js 12 actions are deprecated. For more information see:
   > https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
   > Please update the following actions to use Node.js 16: actions/checkout@v2
* 4248111 Don't cancel the build if one job fails
* 85f3aa7 Avoid running the test suite in a container