### PR TITLE
Update the gem package metadata

### DIFF
--- a/exiv2.gemspec
+++ b/exiv2.gemspec
@@ -12,6 +12,12 @@ Gem::Specification.new do |s|
   s.summary     = %q{A simple wrapper around Exiv2}
   s.description = %q{A simple wrapper around the C++ Exiv2 libary for reading image metadata}
 
+  s.metadata['bug_tracker_uri'] = "#{s.homepage}/issues"
+  s.metadata['changelog_uri'] = "#{s.homepage}/releases"
+  s.metadata['documentation_uri'] = "https://www.rubydoc.info/gems/#{s.name}/#{s.version}"
+  s.metadata['homepage_uri'] = s.homepage
+  s.metadata['source_code_uri'] = "#{s.homepage}/tree/v#{s.version}"
+
   s.rubyforge_project = "exiv2"
 
   s.add_development_dependency "rspec"

--- a/exiv2.gemspec
+++ b/exiv2.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |s|
   s.metadata['homepage_uri'] = s.homepage
   s.metadata['source_code_uri'] = "#{s.homepage}/tree/v#{s.version}"
 
-  s.rubyforge_project = "exiv2"
-
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake-compiler"
 


### PR DESCRIPTION
### Changes

- Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata). These will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/exiv2), via the Rubygems API, and the `gem` and `bundle` command-line tools, after the next release.
- Remove the `rubyforge_project` setting. [Ruby Forge](https://en.wikipedia.org/wiki/RubyForge) has been offline for almost a decade.