### PR TITLE
Remove development and test files from the gem package

### DIFF
--- a/exiv2.gemspec
+++ b/exiv2.gemspec
@@ -17,9 +17,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "rake-compiler"
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |file|
+      file.start_with?('ext', 'lib', 'LICENSE', 'README')
+    end
+  end
   s.require_paths = ["lib", "ext"]
   s.extensions    = ["ext/exiv2/extconf.rb"]
 end


### PR DESCRIPTION
There are a bunch of files in the gem package that aren't useful for downstream projects. Removing these reduces the gem package size from 24K to 9K!

<details><summary>gem contents diff</summary>

```diff
< .github/workflows/test.yml
< .gitignore
< .rspec
< Gemfile
  LICENSE
  README.md
< Rakefile
< exiv2.gemspec
  ext/exiv2/exiv2.cpp
  ext/exiv2/extconf.rb
  lib/exiv2.rb
  lib/exiv2/exif_data.rb
  lib/exiv2/iptc_data.rb
  lib/exiv2/shared_methods.rb
  lib/exiv2/version.rb
  lib/exiv2/xmp_data.rb
< spec/exiv2_spec.rb
< spec/files/photo_with_utf8_description.jpg
< spec/files/test.jpg
```

</details>