### PR TITLE
Fix exiv2 0.28 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ are welcome.
 
 ## Compatibility
 
-Tested on 2.4.x, 2.5.x and 2.6.x with Exiv2 0.27.1
+Tested on 2.6.x, 2.7.x, 3.0.x, 3.1.x and 3.2.x with Exiv2 0.27.1 and 0.28.0.
 
 ## Developing
 

--- a/ext/exiv2/exiv2.cpp
+++ b/ext/exiv2/exiv2.cpp
@@ -1,6 +1,4 @@
 #include "exiv2/exiv2.hpp"
-#include "exiv2/image.hpp"
-#include "exiv2/error.hpp"
 #include "ruby.h"
 
 #if EXIV2_MAJOR_VERSION == 0 && EXIV2_MINOR_VERSION <= 27

--- a/ext/exiv2/extconf.rb
+++ b/ext/exiv2/extconf.rb
@@ -4,6 +4,7 @@ RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
 RbConfig::MAKEFILE_CONFIG['CCFLAGS'] = ENV['CCFLAGS'] if ENV['CCFLAGS']
 RbConfig::MAKEFILE_CONFIG['CXX'] = ENV['CXX'] if ENV['CXX']
 RbConfig::MAKEFILE_CONFIG['CXXFLAGS'] = ENV['CXXFLAGS'] if ENV['CXXFLAGS']
+RbConfig::CONFIG['PKG_CONFIG'] = 'pkg-config'
 
 if dir_config("exiv2") == [nil, nil]
   pkg_config("exiv2")

--- a/ext/exiv2/extconf.rb
+++ b/ext/exiv2/extconf.rb
@@ -7,4 +7,23 @@ if dir_config("exiv2") == [nil, nil]
   pkg_config("exiv2")
 end
 have_library("exiv2")
+
+# Some extensions are optional in versions <= 0.27 and also don't exist in
+# versions >= 0.28.
+# Check if they're enabled in the existing exiv2 headers
+# configuration and include the relevant libraries.
+if have_macro("EXV_USE_SSH", "exiv2/exv_conf.h")
+  if dir_config("libssh") == [nil, nil]
+    pkg_config("libssh")
+  end
+  have_library("libssh")
+end
+
+if have_macro("EXV_USE_CURL", "exiv2/exv_conf.h")
+  if dir_config("libcurl") == [nil, nil]
+    pkg_config("libcurl")
+  end
+  have_library("libcurl")
+end
+
 create_makefile("exiv2/exiv2")

--- a/ext/exiv2/extconf.rb
+++ b/ext/exiv2/extconf.rb
@@ -1,9 +1,6 @@
 require 'mkmf'
 
-RbConfig::MAKEFILE_CONFIG['CC'] = ENV['CC'] if ENV['CC']
-RbConfig::MAKEFILE_CONFIG['CCFLAGS'] = ENV['CCFLAGS'] if ENV['CCFLAGS']
-RbConfig::MAKEFILE_CONFIG['CXX'] = ENV['CXX'] if ENV['CXX']
-RbConfig::MAKEFILE_CONFIG['CXXFLAGS'] = ENV['CXXFLAGS'] if ENV['CXXFLAGS']
+$CXXFLAGS += " -std=c++11"
 RbConfig::CONFIG['PKG_CONFIG'] = 'pkg-config'
 
 if dir_config("exiv2") == [nil, nil]

--- a/lib/exiv2/version.rb
+++ b/lib/exiv2/version.rb
@@ -1,4 +1,4 @@
 # coding: utf-8
 module Exiv2
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Allow compiling with versions both < 0.27 and >= 0.28.
Ensure that if the library is configured with libssh and/or libcurl, we include those in the compilation as well.

Closes #29 