### PR TITLE
CI: add Ruby 3.3 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install libexiv2-dev
         run: |
           sudo apt-get update --quiet


### PR DESCRIPTION
Ruby 3.3 has [been released](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)! Let's add it to the CI build matrix for confidence in compatibility.