### PR TITLE
Require C++ compiler to work

### DIFF
--- a/ext/exiv2/extconf.rb
+++ b/ext/exiv2/extconf.rb
@@ -3,6 +3,9 @@ require 'mkmf'
 $CXXFLAGS += " -std=c++11"
 RbConfig::CONFIG['PKG_CONFIG'] = 'pkg-config'
 
+puts "checking for C++ compiler"
+raise "Cannot use C++ compiler" unless MakeMakefile["C++"].have_devel?
+
 if dir_config("exiv2") == [nil, nil]
   pkg_config("exiv2")
 end


### PR DESCRIPTION
We need to compile c++ sources, so let's make the failure explicit.