### PR TITLE
Drop ruby 2.6 from the supported list

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2', '3.3' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3' ]
     steps:
       - uses: actions/checkout@v4
       - name: Install libexiv2-dev

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ are welcome.
 
 ## Compatibility
 
-Tested on 2.6.x, 2.7.x, 3.0.x, 3.1.x and 3.2.x with Exiv2 0.27.1 and 0.28.0.
+Tested on 2.7.x, 3.0.x, 3.1.x and 3.2.x with Exiv2 0.27.1 and 0.28.0.
 
 ## Developing
 

--- a/exiv2.gemspec
+++ b/exiv2.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/envato/exiv2"
   s.summary     = %q{A simple wrapper around Exiv2}
   s.description = %q{A simple wrapper around the C++ Exiv2 libary for reading image metadata}
+  s.required_ruby_version = '>= 2.7.0'
 
   s.metadata['bug_tracker_uri'] = "#{s.homepage}/issues"
   s.metadata['changelog_uri'] = "#{s.homepage}/releases"


### PR DESCRIPTION
It's been EOL since 2022.